### PR TITLE
Update version to 0.1.1 and correct repository URLs in pyproject.toml…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ A secure file-based key management system that stores cryptographic keys in JSON
 ### Install from source
 
 ```bash
-git clone https://github.com/splurge/splurge-key-custodian-file.git
-cd splurge-key-custodian-file
+git clone https://github.com/splurge/splurge-key-custodian.git
+cd splurge-key-custodian
 pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "splurge-key-custodian"
-version = "0.1.0"
+version = "0.1.1"
 description = "Splurge Key Custodian - File Based Implementation"
 readme = "README.md"
 license = "MIT"
@@ -35,9 +35,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/splurge/splurge-key-custodian-file"
-Repository = "https://github.com/splurge/splurge-key-custodian-file"
-Issues = "https://github.com/splurge/splurge-key-custodian-file/issues"
+Homepage = "https://github.com/splurge/splurge-key-custodian"
+Repository = "https://github.com/splurge/splurge-key-custodian"
+Issues = "https://github.com/splurge/splurge-key-custodian/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
This pull request updates project metadata to reflect a repository rename from `splurge-key-custodian-file` to `splurge-key-custodian`, and bumps the project version. These changes ensure that documentation and project links are accurate and consistent with the new repository name.

Repository and documentation updates:
* Updated all repository URLs in `pyproject.toml` to point to `https://github.com/splurge/splurge-key-custodian` instead of the old `-file` repository.
* Updated the installation instructions in `README.md` to clone from the new repository name.

Versioning:
* Bumped the project version from `0.1.0` to `0.1.1` in `pyproject.toml`.